### PR TITLE
README_FEDORA: mention the GitHub repository instead of the old one

### DIFF
--- a/README_FEDORA
+++ b/README_FEDORA
@@ -1,2 +1,2 @@
 This is a package automatically generated with rosfed.
-See https://pagure.io/ros for more information.
+See https://github.com/morxa/rosfed for more information.


### PR DESCRIPTION
The rosfed repo isn't in Pagure anymore but is still present in this file.